### PR TITLE
Log an error if the user has invalid chains in their .env

### DIFF
--- a/src/utils/wagmi/config.ts
+++ b/src/utils/wagmi/config.ts
@@ -19,6 +19,11 @@ const getTransportsConfig = (): TransportsConfig => {
   const config: TransportsConfig = {};
 
   for (const chain of getEnvEnabledChains()) {
+    if (chain === undefined) {
+      console.error(
+        'Your VITE_CHAINS environment variable is not set correctly, try setting it to something like `VITE_CHAINS="41337,1337,8453,42161"`',
+      );
+    }
     config[chain.id] = http(chain.rpcUrls.default.http[0]);
   }
 


### PR DESCRIPTION
I just ran into this, would be nice to show a warning since we can easily find out where it's happening. Maybe there's a better spot to put this check?