### PR TITLE
Season Table Updates

### DIFF
--- a/src/components/HideColumnDropdown.tsx
+++ b/src/components/HideColumnDropdown.tsx
@@ -10,21 +10,15 @@ import {
 } from "@/components/ui/Dropdown";
 import IconImage from "@/components/ui/IconImage";
 import useIsMobile from "@/hooks/display/useIsMobile";
-import { SeasonColumn, nonHideableFields } from "@/pages/explorer/SeasonsExplorer";
+import { SeasonColumn, nonHideableFields, seasonColumns } from "@/pages/explorer/SeasonsExplorer";
 import { useState } from "react";
 interface HideColumnDropdownProps {
-  seasonColumns: SeasonColumn[];
   hiddenFields: string[];
   toggleColumn: (id: string) => void;
   resetAllHiddenColumns: () => void;
 }
 
-export const HideColumnDropdown = ({
-  seasonColumns,
-  hiddenFields,
-  toggleColumn,
-  resetAllHiddenColumns,
-}: HideColumnDropdownProps) => {
+export const HideColumnDropdown = ({ hiddenFields, toggleColumn, resetAllHiddenColumns }: HideColumnDropdownProps) => {
   const isMobile = useIsMobile();
   const columnDropdownLabel =
     hiddenFields.length > 0

--- a/src/components/tables/SeasonsTable.tsx
+++ b/src/components/tables/SeasonsTable.tsx
@@ -8,6 +8,7 @@ import { DateTime } from "luxon";
 import React, { useEffect, useMemo, useRef, useState } from "react";
 import { ListChildComponentProps, VariableSizeList, areEqual } from "react-window";
 import { SeasonsTableCell, SeasonsTableCellType } from "./SeasonsTableCell";
+import { trulyTheBestTimeFormat } from "@/utils/format";
 
 interface SeasonsTableProps {
   seasonsData: SeasonsTableData[];
@@ -71,7 +72,7 @@ export const SeasonsTable = ({ seasonsData, hiddenFields, hideColumn }: SeasonsT
           className="text-left"
           columnKey="season"
           value={data.season}
-          subValue={DateTime.fromSeconds(data.timestamp).toFormat("yyyy MMM dd t")}
+          subValue={DateTime.fromSeconds(data.timestamp).toFormat(trulyTheBestTimeFormat)}
           hiddenFields={hiddenFields}
         />
         <SeasonsTableCell

--- a/src/components/tables/SeasonsTable.tsx
+++ b/src/components/tables/SeasonsTable.tsx
@@ -3,12 +3,12 @@ import IconImage from "@/components/ui/IconImage";
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/Table";
 import { seasonColumns } from "@/pages/explorer/SeasonsExplorer";
 import { SeasonsTableData } from "@/state/useSeasonsData";
+import { trulyTheBestTimeFormat } from "@/utils/format";
 import { calculateCropScales, caseIdToDescriptiveText, convertDeltaDemandToPercentage } from "@/utils/season";
 import { DateTime } from "luxon";
 import React, { useEffect, useMemo, useRef, useState } from "react";
 import { ListChildComponentProps, VariableSizeList, areEqual } from "react-window";
 import { SeasonsTableCell, SeasonsTableCellType } from "./SeasonsTableCell";
-import { trulyTheBestTimeFormat } from "@/utils/format";
 
 interface SeasonsTableProps {
   seasonsData: SeasonsTableData[];

--- a/src/components/tables/SeasonsTable.tsx
+++ b/src/components/tables/SeasonsTable.tsx
@@ -5,6 +5,7 @@ import useIsMobile from "@/hooks/display/useIsMobile";
 import { seasonColumns } from "@/pages/explorer/SeasonsExplorer";
 import { SeasonsTableData } from "@/state/useSeasonsData";
 import { calculateCropScales, caseIdToDescriptiveText, convertDeltaDemandToPercentage } from "@/utils/season";
+import { DateTime } from "luxon";
 import React, { useEffect, useMemo, useRef, useState } from "react";
 import { ListChildComponentProps, VariableSizeList, areEqual } from "react-window";
 import { SeasonsTableCell, SeasonsTableCellType } from "./SeasonsTableCell";
@@ -63,9 +64,20 @@ export const SeasonsTable = ({ seasonsData, hiddenFields, hideColumn }: SeasonsT
     const data = seasonsData[index];
     const { cropScalar, cropRatio } = calculateCropScales(data.beanToMaxLpGpPerBdvRatio, data.raining, data.season);
     const deltaCropScalar = (data.deltaBeanToMaxLpGpPerBdvRatio / 1e18).toFixed(1);
+    const priceDescriptiveText = caseIdToDescriptiveText(data.caseId, "price");
     return (
       <TableRow key={data.season} style={style} noHoverMute>
-        <SeasonsTableCell className="text-left" columnKey="season" value={data.season} hiddenFields={hiddenFields} />
+        <SeasonsTableCell
+          cellType={SeasonsTableCellType.TwoColumn}
+          className="text-left"
+          columnKey="season"
+          value={data.season}
+          subValue={DateTime.fromSeconds(data.timestamp).toLocaleString({
+            ...DateTime.TIME_24_SIMPLE,
+            ...DateTime.DATETIME_MED,
+          })}
+          hiddenFields={hiddenFields}
+        />
         <SeasonsTableCell
           columnKey="instantDeltaP"
           value={`${data.instDeltaB.toNumber() > 0 ? "+" : ""}${data.instDeltaB.toHuman("short")}`}
@@ -98,11 +110,11 @@ export const SeasonsTable = ({ seasonsData, hiddenFields, hideColumn }: SeasonsT
           hiddenFields={hiddenFields}
         />
         <SeasonsTableCell
-          cellType={SeasonsTableCellType.TwoColumn}
+          cellType={priceDescriptiveText ? SeasonsTableCellType.TwoColumn : SeasonsTableCellType.Default}
           columnKey="twaPrice"
           notApplicable={data.season <= 3}
           value={`$${data.twaPrice.toHuman("short")}`}
-          subValue={caseIdToDescriptiveText(data.caseId, "price")}
+          subValue={priceDescriptiveText}
           hiddenFields={hiddenFields}
         />
         <SeasonsTableCell

--- a/src/components/tables/SeasonsTable.tsx
+++ b/src/components/tables/SeasonsTable.tsx
@@ -1,7 +1,6 @@
 import eyeballCrossed from "@/assets/misc/eyeball-crossed.svg";
 import IconImage from "@/components/ui/IconImage";
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/Table";
-import useIsMobile from "@/hooks/display/useIsMobile";
 import { seasonColumns } from "@/pages/explorer/SeasonsExplorer";
 import { SeasonsTableData } from "@/state/useSeasonsData";
 import { calculateCropScales, caseIdToDescriptiveText, convertDeltaDemandToPercentage } from "@/utils/season";
@@ -72,10 +71,7 @@ export const SeasonsTable = ({ seasonsData, hiddenFields, hideColumn }: SeasonsT
           className="text-left"
           columnKey="season"
           value={data.season}
-          subValue={DateTime.fromSeconds(data.timestamp).toLocaleString({
-            ...DateTime.TIME_24_SIMPLE,
-            ...DateTime.DATETIME_MED,
-          })}
+          subValue={DateTime.fromSeconds(data.timestamp).toFormat("yyyy MMM dd t")}
           hiddenFields={hiddenFields}
         />
         <SeasonsTableCell

--- a/src/components/tables/SeasonsTableCell.tsx
+++ b/src/components/tables/SeasonsTableCell.tsx
@@ -39,10 +39,10 @@ export const SeasonsTableCell = ({
       return (
         <TwoColumnCell
           className={`${className} ${additionalClasses}`}
+          columnKey={columnKey}
           value={displayValue}
           subValue={displaySubValue}
           hoverContent={hoverContent}
-          hiddenFields={hiddenFields}
         />
       );
     default:

--- a/src/components/tables/TwoColumnCell.tsx
+++ b/src/components/tables/TwoColumnCell.tsx
@@ -17,10 +17,11 @@ export const TwoColumnCell = ({
   hoverContent,
 }: TwoColumnCellProps): JSX.Element | null => {
   const itemAlignment = columnKey === "season" ? "items-start" : "items-end";
+  const subValueSize = columnKey === "season" ? "text-[0.75rem]" : "text-sm";
   const cellContent = (
     <div className={`flex flex-col ${itemAlignment}`}>
       <span>{value}</span>
-      <span className="text-xs break-keep text-pinto-gray-4">{subValue}</span>
+      <span className={`${subValueSize} break-keep text-pinto-gray-4`}>{subValue}</span>
     </div>
   );
 

--- a/src/components/tables/TwoColumnCell.tsx
+++ b/src/components/tables/TwoColumnCell.tsx
@@ -3,22 +3,22 @@ import { cn } from "@/utils/utils";
 
 interface TwoColumnCellProps {
   className: string;
+  columnKey: string;
   value: any;
   subValue: any;
   hoverContent?: any;
-  hiddenFields: string[];
 }
 
 export const TwoColumnCell = ({
   className,
+  columnKey,
   value,
   subValue,
   hoverContent,
-  hiddenFields,
 }: TwoColumnCellProps): JSX.Element | null => {
-  if (hiddenFields.includes(value)) return null;
+  const itemAlignment = columnKey === "season" ? "items-start" : "items-end";
   const cellContent = (
-    <div className="flex flex-col items-end">
+    <div className={`flex flex-col ${itemAlignment}`}>
       <span>{value}</span>
       <span className="text-xs break-keep text-pinto-gray-4">{subValue}</span>
     </div>

--- a/src/pages/explorer/SeasonsExplorer.tsx
+++ b/src/pages/explorer/SeasonsExplorer.tsx
@@ -18,7 +18,7 @@ export interface SeasonColumn {
 export const nonHideableFields = ["season"];
 
 export const seasonColumns: SeasonColumn[] = [
-  { id: "season", name: "Season", classes: "text-left  w-[160px]", width: 160 },
+  { id: "season", name: "Season", classes: "text-left  w-[150px]", width: 150 },
   {
     id: "instantDeltaP",
     name: "Instant. ∆P",
@@ -144,7 +144,6 @@ const SeasonsExplorer = () => {
     <>
       <div className="flex flex-row gap-x-2 ml-4">
         <HideColumnDropdown
-          seasonColumns={seasonColumns}
           hiddenFields={hiddenFields}
           toggleColumn={toggleColumn}
           resetAllHiddenColumns={resetAllHiddenColumns}

--- a/src/pages/explorer/SeasonsExplorer.tsx
+++ b/src/pages/explorer/SeasonsExplorer.tsx
@@ -18,7 +18,7 @@ export interface SeasonColumn {
 export const nonHideableFields = ["season"];
 
 export const seasonColumns: SeasonColumn[] = [
-  { id: "season", name: "Season", classes: "text-left  w-[100px]", width: 100 },
+  { id: "season", name: "Season", classes: "text-left  w-[150px]", width: 150 },
   {
     id: "instantDeltaP",
     name: "Instant. ∆P",
@@ -28,7 +28,7 @@ export const seasonColumns: SeasonColumn[] = [
   },
   { id: "twaDeltaP", name: "TWA ∆P", classes: "text-right  w-[125px]", width: 125 },
   { id: "pintoSupply", name: "Pinto Supply", classes: "text-right  w-[135px]", width: 135 },
-  { id: "totalSoil", name: "Total Soil", classes: "text-right  w-[125px]", width: 125 },
+  { id: "totalSoil", name: "Total Soil", classes: "text-right  w-[110px]", width: 110 },
   { id: "soilSown", name: "Soil Sown", classes: "text-right  w-[125px]", width: 125 },
   { id: "timeSown", name: "Time All Sown", classes: "text-right  w-[150px]", width: 150 },
   { id: "price", name: "Price", classes: "text-right  w-[125px]", width: 125 },

--- a/src/pages/explorer/SeasonsExplorer.tsx
+++ b/src/pages/explorer/SeasonsExplorer.tsx
@@ -18,7 +18,7 @@ export interface SeasonColumn {
 export const nonHideableFields = ["season"];
 
 export const seasonColumns: SeasonColumn[] = [
-  { id: "season", name: "Season", classes: "text-left  w-[150px]", width: 150 },
+  { id: "season", name: "Season", classes: "text-left  w-[160px]", width: 160 },
   {
     id: "instantDeltaP",
     name: "Instant. ∆P",

--- a/src/queries/SeasonsTableBean.graphql
+++ b/src/queries/SeasonsTableBean.graphql
@@ -1,6 +1,7 @@
 query seasonsTableBean($from: Int, $to: Int) {
   seasons(first: 1000, orderBy: season, orderDirection: desc, where: {  season_gte: $from, season_lte: $to } ) {
     id
+    timestamp
     beanHourlySnapshot {
       l2sr
       twaPrice

--- a/src/state/useSeasonsData.ts
+++ b/src/state/useSeasonsData.ts
@@ -22,6 +22,7 @@ import useTokenData from "./useTokenData";
 
 export interface SeasonsTableData {
   season: number;
+  timestamp: number;
   caseId: number;
   beanToMaxLpGpPerBdvRatio: number;
   deltaBeanToMaxLpGpPerBdvRatio: number;
@@ -163,6 +164,7 @@ export default function useSeasonsData(fromSeason: number, toSeason: number) {
       acc.push({
         ...acc[season.beanHourlySnapshot.season.season],
         season: season.beanHourlySnapshot.season.season,
+        timestamp: Number(season.timestamp),
         caseId: Number(currFieldHourlySnapshots.caseId || 0),
         instDeltaB: TokenValue.fromHuman(season.beanHourlySnapshot.instDeltaB, tokenData.mainToken.decimals),
         instPrice: TokenValue.fromHuman(season.beanHourlySnapshot.instPrice, tokenData.mainToken.decimals),

--- a/src/utils/__tests/season.test.ts
+++ b/src/utils/__tests/season.test.ts
@@ -1,0 +1,157 @@
+import { describe, expect, it } from "vitest";
+import { calculateCropScales, seasonCutOffFor150, seasonCutOffFor200 } from "../season";
+
+const onePercentScalar = 1e20 * 0.01;
+const twoPercentScalar = 1e20 * 0.02;
+const twentyFivePercentScalar = 1e20 * 0.25;
+const thirtyThreePercentScalar = 1e20 * 0.33;
+const fiftyPercentScalar = 1e20 * 0.5;
+const seventyFivePercentScalar = 1e20 * 0.75;
+const ninetyNinePercentScalar = 1e20 * 0.99;
+
+// crop ratio max 100%
+const firstCaseExpected = {
+  0: {
+    cropScalar: 0,
+    cropRatio: 50,
+  },
+  [onePercentScalar]: {
+    cropScalar: 1,
+    cropRatio: 50.5,
+  },
+  [twoPercentScalar]: {
+    cropScalar: 2,
+    cropRatio: 51,
+  },
+  [twentyFivePercentScalar]: {
+    cropScalar: 25,
+    cropRatio: 62.5,
+  },
+  [thirtyThreePercentScalar]: {
+    cropScalar: 33,
+    cropRatio: 66.5,
+  },
+  [fiftyPercentScalar]: {
+    cropScalar: 50,
+    cropRatio: 75,
+  },
+  [seventyFivePercentScalar]: {
+    cropScalar: 75,
+    cropRatio: 87.5,
+  },
+  [ninetyNinePercentScalar]: {
+    cropScalar: 99,
+    cropRatio: 99.5,
+  },
+  1e20: {
+    cropScalar: 100,
+    cropRatio: 100,
+  },
+};
+
+//crop ratio max 150%
+const secondCaseExpected = {
+  0: {
+    cropScalar: 0,
+    cropRatio: 50,
+  },
+  [onePercentScalar]: {
+    cropScalar: 1,
+    cropRatio: 51,
+  },
+  [twoPercentScalar]: {
+    cropScalar: 2,
+    cropRatio: 52,
+  },
+  [twentyFivePercentScalar]: {
+    cropScalar: 25,
+    cropRatio: 75,
+  },
+  [thirtyThreePercentScalar]: {
+    cropScalar: 33,
+    cropRatio: 83,
+  },
+  [fiftyPercentScalar]: {
+    cropScalar: 50,
+    cropRatio: 100,
+  },
+  [seventyFivePercentScalar]: {
+    cropScalar: 75,
+    cropRatio: 125,
+  },
+  [ninetyNinePercentScalar]: {
+    cropScalar: 99,
+    cropRatio: 149,
+  },
+  1e20: {
+    cropScalar: 100,
+    cropRatio: 150,
+  },
+};
+
+// crop ratio max 200%
+const thirdCaseExpected = {
+  0: {
+    cropScalar: 0,
+    cropRatio: 50,
+  },
+  [onePercentScalar]: {
+    cropScalar: 1,
+    cropRatio: 51.5,
+  },
+  [twoPercentScalar]: {
+    cropScalar: 2,
+    cropRatio: 53,
+  },
+  [twentyFivePercentScalar]: {
+    cropScalar: 25,
+    cropRatio: 87.5,
+  },
+  [thirtyThreePercentScalar]: {
+    cropScalar: 33,
+    cropRatio: 99.5,
+  },
+  [fiftyPercentScalar]: {
+    cropScalar: 50,
+    cropRatio: 125,
+  },
+  [seventyFivePercentScalar]: {
+    cropScalar: 75,
+    cropRatio: 162.5,
+  },
+  [ninetyNinePercentScalar]: {
+    cropScalar: 99,
+    cropRatio: 198.5,
+  },
+  1e20: {
+    cropScalar: 100,
+    cropRatio: 200,
+  },
+};
+
+describe("calculateCropScales", () => {
+  it.each(Object.keys(firstCaseExpected))(
+    "should calculate crop scalars correctly for seasons where crop ratio max is 100%",
+    (cropScalarInput) => {
+      const expectedCropScales = firstCaseExpected[cropScalarInput];
+      const cropScales = calculateCropScales(Number(cropScalarInput), false, 1);
+      expect(cropScales).toEqual(expectedCropScales);
+    },
+  );
+  it.each(Object.keys(secondCaseExpected))(
+    "should calculate crop scalars correctly for seasons where crop ratio max is 150%",
+    (cropScalarInput) => {
+      const expectedCropScales = secondCaseExpected[cropScalarInput];
+      const cropScales = calculateCropScales(Number(cropScalarInput), false, seasonCutOffFor150);
+      expect(cropScales).toEqual(expectedCropScales);
+    },
+  );
+  it.each(Object.keys(thirdCaseExpected))(
+    "should calculate crop scalars correctly for seasons where crop ratio max is 200%",
+    (cropScalarInput) => {
+      const expectedCropScales = thirdCaseExpected[cropScalarInput];
+      const cropScales = calculateCropScales(Number(cropScalarInput), false, seasonCutOffFor200);
+      expect(cropScales).toEqual(expectedCropScales);
+    },
+  );
+});

--- a/src/utils/__tests/season.test.ts
+++ b/src/utils/__tests/season.test.ts
@@ -49,6 +49,45 @@ const firstCaseExpected = {
   },
 };
 
+const firstCaseExpectedRaining = {
+  0: {
+    cropScalar: 0,
+    cropRatio: 33,
+  },
+  [onePercentScalar]: {
+    cropScalar: 1,
+    cropRatio: 33.7,
+  },
+  [twoPercentScalar]: {
+    cropScalar: 2,
+    cropRatio: 34.3,
+  },
+  [twentyFivePercentScalar]: {
+    cropScalar: 25,
+    cropRatio: 49.8,
+  },
+  [thirtyThreePercentScalar]: {
+    cropScalar: 33,
+    cropRatio: 55.1,
+  },
+  [fiftyPercentScalar]: {
+    cropScalar: 50,
+    cropRatio: 66.5,
+  },
+  [seventyFivePercentScalar]: {
+    cropScalar: 75,
+    cropRatio: 83.3,
+  },
+  [ninetyNinePercentScalar]: {
+    cropScalar: 99,
+    cropRatio: 99.3,
+  },
+  1e20: {
+    cropScalar: 100,
+    cropRatio: 100,
+  },
+};
+
 //crop ratio max 150%
 const secondCaseExpected = {
   0: {
@@ -135,6 +174,14 @@ describe("calculateCropScales", () => {
     (cropScalarInput) => {
       const expectedCropScales = firstCaseExpected[cropScalarInput];
       const cropScales = calculateCropScales(Number(cropScalarInput), false, 1);
+      expect(cropScales).toEqual(expectedCropScales);
+    },
+  );
+  it.each(Object.keys(firstCaseExpectedRaining))(
+    "should calculate crop scalars correctly for seasons where crop ratio max is 100% and it is raining",
+    (cropScalarInput) => {
+      const expectedCropScales = firstCaseExpectedRaining[cropScalarInput];
+      const cropScales = calculateCropScales(Number(cropScalarInput), true, 1);
       expect(cropScales).toEqual(expectedCropScales);
     },
   );

--- a/src/utils/format.ts
+++ b/src/utils/format.ts
@@ -259,3 +259,5 @@ export function toFixedNumber(num: number, digits: number, base?: number) {
   const pow = (base ?? 10) ** digits;
   return Math.round(num * pow) / pow;
 }
+
+export const trulyTheBestTimeFormat = "yyyy MMM dd, t";

--- a/src/utils/season.ts
+++ b/src/utils/season.ts
@@ -44,10 +44,8 @@ export function convertDeltaDemandToPercentage(deltaDemand: number) {
 export function caseIdToDescriptiveText(caseId: number, column: "price" | "soil_demand" | "pod_rate" | "l2sr") {
   switch (column) {
     case "price":
-      if ((caseId % 36) % 9 < 3) return "P < $1.00";
-      else if ((caseId % 36) % 9 < 6) return "P > $1.00";
-      //(caseId % 36 < 9)
-      else return "P > Q";
+      if ((caseId % 36) % 9 >= 6) return "P > Q";
+      else return undefined;
     case "soil_demand":
       if (caseId % 3 === 0) return "Decreasing";
       else if (caseId % 3 === 1) return "Steady";

--- a/src/utils/season.ts
+++ b/src/utils/season.ts
@@ -1,15 +1,29 @@
 import { TokenValue } from "@/classes/TokenValue";
 import { toFixedNumber } from "./format";
+
+export const seasonCutOffFor150 = 2710;
+export const seasonCutOffFor200 = 5000; // placeholder value, will likely be in the 3400-3600 range
+
+const getMaxCropRatioBySeason = (season: number) => {
+  if (season >= seasonCutOffFor150 && season < seasonCutOffFor200) {
+    return 150;
+  }
+  if (season >= seasonCutOffFor200) {
+    return 200;
+  }
+  return 100;
+};
+
 export function calculateCropScales(value: number, isRaining: boolean, season: number) {
   const maxInput = 1e18;
-  const maxOutput = season >= 2710 ? 150 : 100;
+  const maxOutput = getMaxCropRatioBySeason(season);
 
-  // Calculate crop scalar
   const cropScalar = toFixedNumber(value / maxInput, 1);
-
-  // Calculate crop ratio
+  const asAScalar = value / maxInput / 100;
   const minCropRatio = isRaining ? 33 : 50;
-  const cropRatio = Math.min(maxOutput, Math.max(minCropRatio, (cropScalar / 100) * maxOutput)).toFixed(1);
+
+  // round to nearest one decimal without converting to string or adding trailing zeroes to integers
+  const cropRatio = Math.round((asAScalar * (maxOutput - minCropRatio) + minCropRatio) * 10) / 10;
 
   return {
     cropScalar,


### PR DESCRIPTION
- change P > Q to excessively high
    - remove the other cases
- add date to season field
- fix crop ratio calculation
- add a lot of crop ratio tests so we don't have to change it again

Note: I've temporarily set the 200% crop ratio cutoff at season 5000 to get tests for it and prepare for PI-8 but we will need to update this once we know the actual season that it ends up getting implemented at

Date column + P>Q being the only displayed descriptive text for TWA price, others removed
<img width="294" alt="CleanShot 2025-04-11 at 07 49 35@2x" src="https://github.com/user-attachments/assets/b1852460-c451-4b45-9a9d-12bd3cfdf003" />


crop ratio calculation more better
<img width="281" alt="CleanShot 2025-04-11 at 07 40 15@2x" src="https://github.com/user-attachments/assets/c20ad1fc-05ef-4eb5-b494-b501f01464fe" />
