### PR TITLE
Update Seasons Table for PI-8

### DIFF
--- a/src/components/tables/SeasonsTable.tsx
+++ b/src/components/tables/SeasonsTable.tsx
@@ -135,9 +135,9 @@ export const SeasonsTable = ({ seasonsData, hiddenFields, hideColumn }: SeasonsT
           value={convertDeltaDemandToPercentage(data.deltaPodDemand.toNumber())}
           subValue={caseIdToDescriptiveText(data.caseId, "soil_demand")}
           hiddenFields={hiddenFields}
-        // hoverContent={
-        //   <DeltaDemandChart />
-        // }
+          // hoverContent={
+          //   <DeltaDemandChart />
+          // }
         />
         <SeasonsTableCell
           columnKey="cropScalar"

--- a/src/components/tables/SeasonsTable.tsx
+++ b/src/components/tables/SeasonsTable.tsx
@@ -69,7 +69,7 @@ export const SeasonsTable = ({ seasonsData, hiddenFields, hideColumn }: SeasonsT
       <TableRow key={data.season} style={style} noHoverMute>
         <SeasonsTableCell
           cellType={SeasonsTableCellType.TwoColumn}
-          className="text-left"
+          className="text-left h-[50px]"
           columnKey="season"
           value={data.season}
           subValue={DateTime.fromSeconds(data.timestamp).toFormat(trulyTheBestTimeFormat)}
@@ -135,9 +135,9 @@ export const SeasonsTable = ({ seasonsData, hiddenFields, hideColumn }: SeasonsT
           value={convertDeltaDemandToPercentage(data.deltaPodDemand.toNumber())}
           subValue={caseIdToDescriptiveText(data.caseId, "soil_demand")}
           hiddenFields={hiddenFields}
-          // hoverContent={
-          //   <DeltaDemandChart />
-          // }
+        // hoverContent={
+        //   <DeltaDemandChart />
+        // }
         />
         <SeasonsTableCell
           columnKey="cropScalar"

--- a/src/utils/season.ts
+++ b/src/utils/season.ts
@@ -2,7 +2,9 @@ import { TokenValue } from "@/classes/TokenValue";
 import { toFixedNumber } from "./format";
 
 export const seasonCutOffFor150 = 2710;
-export const seasonCutOffFor200 = 5000; // placeholder value, will likely be in the 3400-3600 range TODO: FLOYD / burr please change!
+// it's actually 3572 but theres an oddity with subgraph that gave us the value mid-season so we need to
+// calculate season 3571 as if the max crop ratio is 200
+export const seasonCutOffFor200 = 3571;
 
 const getMaxCropRatioBySeason = (season: number) => {
   if (season >= seasonCutOffFor150 && season < seasonCutOffFor200) {
@@ -52,9 +54,12 @@ export function caseIdToDescriptiveText(rawCaseID: number, column: "price" | "so
       else if (caseId % 3 === 1) return "Steady";
       else return "Increasing";
     case "pod_rate":
-      if ((caseId % 36) / 9 === 0) return "Excessively Low";
-      else if ((caseId % 36) / 9 === 1) return "Reasonably Low";
-      else if ((caseId % 36) / 9 === 2) return "Reasonably High";
+      // pod rate > 100 case
+      if (rawCaseID > 1000) return "Extremely High";
+      // otherwise use original logic
+      if (Math.trunc((caseId % 36) / 9) === 0) return "Excessively Low";
+      else if (Math.trunc((caseId % 36) / 9) === 1) return "Reasonably Low";
+      else if (Math.trunc((caseId % 36) / 9) === 2) return "Reasonably High";
       else return "Excessively High";
     case "l2sr":
       if (Math.trunc(caseId / 36) === 0) {

--- a/src/utils/season.ts
+++ b/src/utils/season.ts
@@ -2,7 +2,7 @@ import { TokenValue } from "@/classes/TokenValue";
 import { toFixedNumber } from "./format";
 
 export const seasonCutOffFor150 = 2710;
-export const seasonCutOffFor200 = 5000; // placeholder value, will likely be in the 3400-3600 range
+export const seasonCutOffFor200 = 5000; // placeholder value, will likely be in the 3400-3600 range TODO: FLOYD / burr please change!
 
 const getMaxCropRatioBySeason = (season: number) => {
   if (season >= seasonCutOffFor150 && season < seasonCutOffFor200) {
@@ -41,7 +41,11 @@ export function convertDeltaDemandToPercentage(deltaDemand: number) {
   return `${TokenValue.fromHuman(scaledValue, 0).toHuman("short")}%`;
 }
 
-export function caseIdToDescriptiveText(caseId: number, column: "price" | "soil_demand" | "pod_rate" | "l2sr") {
+export function caseIdToDescriptiveText(rawCaseID: number, column: "price" | "soil_demand" | "pod_rate" | "l2sr") {
+  let caseId = rawCaseID;
+  if (rawCaseID > 1000) {
+    caseId = rawCaseID - 1000;
+  }
   switch (column) {
     case "price":
       if ((caseId % 36) % 9 >= 6) return "P > Q";

--- a/src/utils/season.ts
+++ b/src/utils/season.ts
@@ -42,10 +42,7 @@ export function convertDeltaDemandToPercentage(deltaDemand: number) {
 }
 
 export function caseIdToDescriptiveText(rawCaseID: number, column: "price" | "soil_demand" | "pod_rate" | "l2sr") {
-  let caseId = rawCaseID;
-  if (rawCaseID > 1000) {
-    caseId = rawCaseID - 1000;
-  }
+  const caseId = rawCaseID > 1000 ? rawCaseID - 1000 : rawCaseID;
   switch (column) {
     case "price":
       if ((caseId % 36) % 9 >= 6) return "P > Q";


### PR DESCRIPTION
Targeting the other PI-8 update branch for UI so we only have to put in one.

Change the season cutoff for 200% to 3571 (really 3572 but theres an issue)

Update the descriptive text in two ways. 

1) Add the caseId > 1000 case for pod rate = "Extremely High"
2) I found a bug in that we aren't truncating the value for pod rate so we almost always fall through to excessively high (which has been true recently, but if you look back at season 90 it also says excessively high

FInally I updated the table row height for odd screen sizes because it had been bothering me. I fixed it in the soil demand chart but I don't want to wait until that goes in to fix it