### PR TITLE
Fix pinto sown per order

### DIFF
--- a/src/lib/Tractor/utils.ts
+++ b/src/lib/Tractor/utils.ts
@@ -733,15 +733,13 @@ export async function fetchTractorExecutions(
             topics: log.topics,
           });
 
-          if (decoded.eventName === "TractorExecutionBegan" &&
-            decoded.args?.blueprintHash === blueprintHash) {
+          if (decoded.eventName === "TractorExecutionBegan" && decoded.args?.blueprintHash === blueprintHash) {
             tractorExecutionBeganIndex = i;
             tractorExecutionBeganEvent = decoded;
             break;
           }
         } catch {
           // Skip logs that can't be decoded
-          continue;
         }
       }
 
@@ -763,7 +761,6 @@ export async function fetchTractorExecutions(
             }
           } catch {
             // Skip logs that can't be decoded
-            continue;
           }
         }
       }
@@ -791,20 +788,22 @@ export async function fetchTractorExecutions(
       }
 
       // Create the tractorExecutionBeganData object conditionally
-      const tractorExecutionBeganData = tractorExecutionBeganEvent ? {
-        operator: tractorExecutionBeganEvent.args?.operator as `0x${string}`,
-        publisher: tractorExecutionBeganEvent.args?.publisher as `0x${string}`,
-        blueprintHash: tractorExecutionBeganEvent.args?.blueprintHash as `0x${string}`,
-        nonce: tractorExecutionBeganEvent.args?.nonce as bigint,
-        gasleft: tractorExecutionBeganEvent.args?.gasleft as bigint
-      } : undefined;
+      const tractorExecutionBeganData = tractorExecutionBeganEvent
+        ? {
+            operator: tractorExecutionBeganEvent.args?.operator as `0x${string}`,
+            publisher: tractorExecutionBeganEvent.args?.publisher as `0x${string}`,
+            blueprintHash: tractorExecutionBeganEvent.args?.blueprintHash as `0x${string}`,
+            nonce: tractorExecutionBeganEvent.args?.nonce as bigint,
+            gasleft: tractorExecutionBeganEvent.args?.gasleft as bigint,
+          }
+        : undefined;
 
       return {
         blockNumber: receipt.blockNumber,
         event,
         receipt,
         sowData,
-        tractorExecutionBeganEvent: tractorExecutionBeganData
+        tractorExecutionBeganEvent: tractorExecutionBeganData,
       };
     }),
   );
@@ -830,7 +829,7 @@ export async function fetchTractorExecutions(
       transactionHash: result.event.transactionHash,
       timestamp: blockTimestamps.get(result.blockNumber.toString()),
       sowEvent: result.sowData,
-      tractorExecutionBeganEvent: result.tractorExecutionBeganEvent
+      tractorExecutionBeganEvent: result.tractorExecutionBeganEvent,
     };
   });
 }

--- a/src/lib/Tractor/utils.ts
+++ b/src/lib/Tractor/utils.ts
@@ -717,7 +717,10 @@ export async function fetchTractorExecutions(
       // Add block number to the set for batch fetching
       blockNumbers.add(receipt.blockNumber);
 
-      // First, find the TractorExecutionBegan event with matching publisher
+      // Get the blueprint hash from the Tractor event
+      const blueprintHash = event.args?.blueprintHash as `0x${string}`;
+
+      // First, find the TractorExecutionBegan event with matching blueprint hash
       let tractorExecutionBeganIndex = -1;
       let tractorExecutionBeganEvent: any = null;
 
@@ -731,7 +734,7 @@ export async function fetchTractorExecutions(
           });
 
           if (decoded.eventName === "TractorExecutionBegan" &&
-            decoded.args?.publisher?.toLowerCase() === publisher.toLowerCase()) {
+            decoded.args?.blueprintHash === blueprintHash) {
             tractorExecutionBeganIndex = i;
             tractorExecutionBeganEvent = decoded;
             break;


### PR DESCRIPTION
Top screenshot is what the UI currently shows (wrong)
Bottom screen shot is what this PR shows (fixed!!)

The problem was that in the txn, we were looking for just the first sow event and assume that was the one correlated with the blueprint we were looking at, but roastbeef is executing multiple orders in one txn, so this first looks for where the tractor execution started for that blueprint, and then looks at the next sow after that.

Test user: `0x5270c860a816290a71494e7cD58e7AD6D12AAd9F`

<img width="1309" alt="Screenshot 2025-04-30 at 11 32 49" src="https://github.com/user-attachments/assets/e0e03395-88cd-4bea-9d68-5caafd56d149" />
<img width="1305" alt="Screenshot 2025-04-30 at 11 32 57" src="https://github.com/user-attachments/assets/82ee681f-ff4f-47ae-9ec9-2cb4ebb0205f" />
