### PR TITLE
Disable query persist

### DIFF
--- a/src/state/seasonal/queries/useSeasonalInternalQueries.ts
+++ b/src/state/seasonal/queries/useSeasonalInternalQueries.ts
@@ -90,9 +90,10 @@ export default function useSeasonalQueries<T>(
     gcTime: 24 * 24 * 60 * 60 * 1000,
     retry: 1,
     retryDelay: 2000,
-    meta: {
-      persist: true,
-    },
+    // Disabled temporarily due to large data size appearing to break it
+    // meta: {
+    //   persist: true,
+    // },
   });
 
   let historicalData: SeasonalChartData[] | undefined = historical.data;
@@ -221,9 +222,10 @@ export function useMultiSeasonalQueries<T>(
     staleTime: Infinity,
     retry: 1,
     retryDelay: 2000,
-    meta: {
-      persist: true,
-    },
+    // Disabled temporarily due to large data size appearing to break it
+    // meta: {
+    //   persist: true,
+    // },
   });
 
   const historicalData: { [key: string]: SeasonalChartData[] } | undefined = historical.data;


### PR DESCRIPTION
Persisted queries are returning {} on subsequent retrievals. Appears to be due to large data size

![image](https://github.com/user-attachments/assets/c1dcfdc2-de34-4847-96d4-3084c277a2da)