### PR TITLE
fix: default to using silo deposits in sPinto wrap page

### DIFF
--- a/src/pages/silo/actions/WrapToken.tsx
+++ b/src/pages/silo/actions/WrapToken.tsx
@@ -228,6 +228,8 @@ export default function WrapToken({ siloToken }: { siloToken: Token }) {
 
     if (deposits?.amount.lte(0)) {
       setSource("balances");
+    } else {
+      setSource("deposits");
     }
 
     setDidInitSource(true);


### PR DESCRIPTION
Fixes #119

This PR addresses the UX issue where the sPinto wrap page didn't default to using silo deposits when they were available.

## Changes
- Modified useEffect in WrapToken.tsx to automatically set source to "deposits" when user has deposited pinto
- Improved UX by eliminating the need for users to manually toggle to use their deposits

## Testing
- Users with pinto deposited in silo should now see the "Use PINTO deposits" toggle enabled by default
- Users without deposits will continue to see wallet balances as default

Generated with [Claude Code](https://claude.ai/code)