### PR TITLE
fix: correct x-axis range for Average Sown Temperature Graph

### DIFF
--- a/src/pages/field/FieldTemperatureBarChart.tsx
+++ b/src/pages/field/FieldTemperatureBarChart.tsx
@@ -8,7 +8,7 @@ import useBucketedFieldPlotSummary, {
   aggregateFieldPlotBucketSummary,
   FieldPlotBucketSummary,
 } from "@/state/useBucketedFieldPlotSummary";
-import { useHarvestableIndex } from "@/state/useFieldData";
+import { useHarvestableIndex, usePodIndex } from "@/state/useFieldData";
 import { formatter, numberAbbr } from "@/utils/format";
 import { useDebounceValue } from "@/utils/useDebounce";
 import { cn, exists } from "@/utils/utils";
@@ -27,6 +27,7 @@ const BUCKET_SIZE = 50_000;
 const FieldTemperatureBarChart = React.memo(({ className, variant = "default" }: FieldTemperatureBarChartProps) => {
   // global state
   const harvestableIndex = useHarvestableIndex();
+  const podIndex = usePodIndex();
 
   // local State
   const [activeIndex, setActiveIndex] = useState<number | undefined>(undefined);
@@ -36,20 +37,20 @@ const FieldTemperatureBarChart = React.memo(({ className, variant = "default" }:
     (data: FieldPlotBucketSummary[] | undefined) => {
       let datas: FieldPlotBucketSummary[] = [];
 
-      if (data && harvestableIndex.gt(0)) {
+      if (data && podIndex.gt(0)) {
         const maxLookback = getTimestampLookback(tab);
         const filtered = data.filter((d) => d.startTimestamp > maxLookback);
 
         datas = filtered.map((d) => ({
           ...d,
-          startIndex: d.startIndex.sub(harvestableIndex),
-          endIndex: d.endIndex.sub(harvestableIndex),
+          startIndex: d.startIndex.sub(podIndex),
+          endIndex: d.endIndex.sub(podIndex),
         }));
       }
 
       return aggregateFieldPlotBucketSummary(datas);
     },
-    [harvestableIndex, tab],
+    [podIndex, tab],
   );
 
   // queries
@@ -62,7 +63,7 @@ const FieldTemperatureBarChart = React.memo(({ className, variant = "default" }:
   const chartData = useTransformBucketedFieldPlotSummary(summaryData?.data);
 
   // derived state
-  const isLoading = query.isLoading || harvestableIndex.lte(0);
+  const isLoading = query.isLoading || podIndex.lte(0);
 
   // Debounce the active index to prevent too many re-renders
   const debouncedActiveIndex = useDebounceValue(activeIndex, 10);


### PR DESCRIPTION
Fixes #122

## Summary
- Fixed x-axis range calculation for Average Sown Temperature Graph
- Replaced harvestableIndex with podIndex as reference point
- Now shows correct range relative to current podline end position

## Changes
- Updated `src/pages/field/FieldTemperatureBarChart.tsx`
- Added usePodIndex hook import
- Modified handleSelect function to use podIndex instead of harvestableIndex
- Updated loading condition to check podIndex

## Test Plan
1. Navigate to Explorer > Field tab
2. View the Average Sown Temperature graph
3. Switch between Week/Month time periods
4. Verify x-axis shows correct podline ranges instead of starting at 0

Generated with [Claude Code](https://claude.ai/code)