### PR TITLE
Fix Global Time Selector refactor

### DIFF
--- a/src/hooks/useSharedTimeTab.ts
+++ b/src/hooks/useSharedTimeTab.ts
@@ -32,7 +32,6 @@ const chartTabFamily = atomFamily(
 
 type UseSharedTimeTabReturn = readonly [tab: TimeTab, setTab: (tab: TimeTab) => void];
 
-
 export const useSharedTimeTab = (
   chartId?: string,
   defaultOverride?: TimeTab,

--- a/src/pages/field/FieldTemperatureBarChart.tsx
+++ b/src/pages/field/FieldTemperatureBarChart.tsx
@@ -31,7 +31,7 @@ const FieldTemperatureBarChart = React.memo(({ className, variant = "default" }:
 
   // local State
   const [activeIndex, setActiveIndex] = useState<number | undefined>(undefined);
-  const [explorerTab, setExplorerTab] = useSharedTimeTab("fieldTemperature");
+  const [explorerTab, setExplorerTab] = useSharedTimeTab("fieldTemperature", TimeTab.AllTime);
   const [localTab, setLocalTab] = useState<TimeTab>(TimeTab.AllTime);
 
   const [tab, setTab] = variant === "explorer" ? [explorerTab, setExplorerTab] : [localTab, setLocalTab];


### PR DESCRIPTION
 - Override clearing: When global tab changes, all chart overrides are cleared
  (maintains original behavior)
  - Context isolation: Different contextKey values create independent state management
  - Default overrides: Charts can have initial override values that don't interfere
  with each other

  📈 Performance Impact

  - Significantly reduced re-renders across the application
  - More efficient memory usage and removed potential memory leaks.
  - Faster component updates due to targeted subscriptions

Expected behavior
  - Enables default tab selection given chartId. ('All time tab as default for avg temperature chart')
  - Add context level isolation with 'contextKey'.
  - All chart time-tab overrides clear when main context hook unmounts but persist while main context hook is mounted (ex: When on the explorer page, all time tab changes persist. When user navigates away from explorer page, they clear)