### PR TITLE
fix: filter tractor orders by soil-constrained amount

### DIFF
--- a/src/pages/field/FieldActivity.tsx
+++ b/src/pages/field/FieldActivity.tsx
@@ -88,7 +88,7 @@ const FieldActivity = () => {
   const loadingActivity = isActivitiesLoading || !activities;
 
   const ordersWithSowableAmount = useMemo(
-    () => tractorOrders?.filter((order) => order.amountSowableNextSeason.gt(0)),
+    () => tractorOrders?.filter((order) => order.amountSowableNextSeasonConsideringAvailableSoil.gt(0)),
     [tractorOrders],
   );
 


### PR DESCRIPTION
Fix bug where field activity shows pending tractor orders that appear executable but cannot run due to insufficient soil.

## Changes
- Update filtering logic in `FieldActivity.tsx` to use `amountSowableNextSeasonConsideringAvailableSoil` instead of `amountSowableNextSeason`
- Ensures tractor orders are only displayed when they can actually execute given soil availability

## Testing
- Manual validation of logic alignment between filtering and display
- Verified that display logic already uses the correct soil-constrained field

Closes #146

Generated with [Claude Code](https://claude.ai/code)