### PR TITLE
fix: include final interval (25th) in morning auction chart

### DIFF
--- a/src/components/charts/LineChart.tsx
+++ b/src/components/charts/LineChart.tsx
@@ -244,7 +244,7 @@ const LineChart = React.memo(
                     return tickLabel;
                   }
 
-                  const indicesToShowTicks = [4, 9, 14, 19, 24];
+                  const indicesToShowTicks = [5, 10, 15, 20];
 
                   if (indicesToShowTicks.includes(index)) {
                     return tickLabel;

--- a/src/components/charts/LineChart.tsx
+++ b/src/components/charts/LineChart.tsx
@@ -244,7 +244,7 @@ const LineChart = React.memo(
                     return tickLabel;
                   }
 
-                  const indicesToShowTicks = [4, 9, 14, 19];
+                  const indicesToShowTicks = [4, 9, 14, 19, 24];
 
                   if (indicesToShowTicks.includes(index)) {
                     return tickLabel;

--- a/src/components/charts/chartHelpers.ts
+++ b/src/components/charts/chartHelpers.ts
@@ -495,7 +495,7 @@ const getXScaleTick = (
     if (index === 0 || index === ticks.length - 1) {
       return tickLabel;
     }
-    const indicesToShowTicks = [4, 9, 14, 19];
+    const indicesToShowTicks = [4, 9, 14, 19, 24];
     return indicesToShowTicks.includes(index) ? tickLabel : "";
   }
 

--- a/src/components/charts/chartHelpers.ts
+++ b/src/components/charts/chartHelpers.ts
@@ -495,7 +495,7 @@ const getXScaleTick = (
     if (index === 0 || index === ticks.length - 1) {
       return tickLabel;
     }
-    const indicesToShowTicks = [4, 9, 14, 19, 24];
+    const indicesToShowTicks = [5, 10, 15, 20];
     return indicesToShowTicks.includes(index) ? tickLabel : "";
   }
 

--- a/src/pages/field/MorningTemperature.tsx
+++ b/src/pages/field/MorningTemperature.tsx
@@ -83,7 +83,7 @@ const Stat = ({
 
   return (
     <div className="flex flex-col w-full gap-1">
-      <div className="pinto-sm">Current Temperature {clampedIndex + 1}/26</div>
+      <div className="pinto-sm">Current Temperature {clampedIndex}/25</div>
       <div className="flex flex-col gap-2">
         <div className="pinto-sm-thin text-pinto-light">
           <MorningIntervalCountdown prefix={"Increasing in"} />

--- a/src/pages/field/MorningTemperature.tsx
+++ b/src/pages/field/MorningTemperature.tsx
@@ -77,13 +77,13 @@ const Stat = ({
   const morningIndex = morning.index > 25 ? 25 : morning.index < 0 ? 0 : morning.index;
 
   const index = hoveredIndex ?? morningIndex;
-  const clampedIndex = index > 25 ? 24 : index < 0 ? 0 : index;
+  const clampedIndex = index > 25 ? 25 : index < 0 ? 0 : index;
 
   const displayTemp = data[clampedIndex]?.values?.[0];
 
   return (
     <div className="flex flex-col w-full gap-1">
-      <div className="pinto-sm">Current Temperature {clampedIndex + 1}/25</div>
+      <div className="pinto-sm">Current Temperature {clampedIndex + 1}/26</div>
       <div className="flex flex-col gap-2">
         <div className="pinto-sm-thin text-pinto-light">
           <MorningIntervalCountdown prefix={"Increasing in"} />

--- a/src/state/useCalculateTemperature.ts
+++ b/src/state/useCalculateTemperature.ts
@@ -19,7 +19,7 @@ export type MorningTemperatureLookup = {
   [blockNumber: string]: MorningBlockTemperature;
 };
 
-const intervalBlocks = Array.from({ length: INTERVALS_PER_MORNING }, (_, i) => i);
+const intervalBlocks = Array.from({ length: INTERVALS_PER_MORNING + 1 }, (_, i) => i);
 
 export default function useCalculateTemperature(): {
   generate: () => MorningTemperatureLookup;

--- a/src/state/useCalculateTemperature.ts
+++ b/src/state/useCalculateTemperature.ts
@@ -11,7 +11,7 @@ export type MorningBlockTemperature = {
   maxTemperature: TV;
   /** */
   index: number;
-  /** index + 1  */
+  /** interval index (0-25) */
   interval: number;
 };
 
@@ -49,7 +49,7 @@ export default function useCalculateTemperature(): {
 
       prev[index] = {
         index: i,
-        interval: i + 1,
+        interval: i,
         temperature: calculate(i),
         maxTemperature: maxTemperature,
       };


### PR DESCRIPTION
The morning auction chart was only showing intervals 1-25 but missing the final interval when the auction ends. This change:

- Generates 26 intervals (0-25) instead of 25 (0-24) in useCalculateTemperature
- Updates display logic to properly handle the final interval at index 25
- Changes display text from "X/25" to "X/26" to reflect the actual total
- Ensures the final interval shows maximum temperature when auction ends

🤖 Generated with [Claude Code](https://claude.ai/code)