### PR TITLE
feat: Update blog navigation with official and community blog links

### DIFF
--- a/src/components/nav/nav/Navbar.tsx
+++ b/src/components/nav/nav/Navbar.tsx
@@ -334,5 +334,6 @@ export const navLinks = {
   github: "https://github.com/pinto-org",
   disclosures: "https://docs.pinto.money/disclosures",
   exchange: "https://pinto.exchange/",
-  blog: "https://mirror.xyz/0xEA13D1fB14934E41Ee7074198af8F089a6d956B5",
+  blog: "https://mirror.xyz/0x8F02813a0AC20affC2C7568e0CB9a7cE5288Ab27",
+  communityBlog: "https://mirror.xyz/0xe7731147bBe1BEBe5CF1Ab101C6EceD384dAbD07",
 } as const;

--- a/src/components/nav/nav/Navi.desktop.tsx
+++ b/src/components/nav/nav/Navi.desktop.tsx
@@ -144,7 +144,12 @@ const LearnNavi = ({ setNaviTab }) => {
           </NavigationMenuItem>
           <NavigationMenuItem>
             <Link href={navLinks.blog} rel="noopener noreferrer" target="_blank">
-              Blog
+              Official Blog
+            </Link>
+          </NavigationMenuItem>
+          <NavigationMenuItem>
+            <Link href={navLinks.communityBlog} rel="noopener noreferrer" target="_blank">
+              Community Blog
             </Link>
           </NavigationMenuItem>
           <NavigationMenuItem>

--- a/src/components/nav/nav/Navi.mobile.tsx
+++ b/src/components/nav/nav/Navi.mobile.tsx
@@ -206,8 +206,11 @@ function MobileNavContent({ learnOpen, moreOpen, setLearnOpen, setMoreOpen, unmo
                 <MobileNavLink variant="h4" nested external href={navLinks.docs} onClick={unmountAndClose}>
                   Docs
                 </MobileNavLink>
-                <MobileNavLink variant="h4" nested href={navLinks.blog} onClick={unmountAndClose}>
-                  Blog
+                <MobileNavLink variant="h4" nested external href={navLinks.blog} onClick={unmountAndClose}>
+                  Official Blog
+                </MobileNavLink>
+                <MobileNavLink variant="h4" nested external href={navLinks.communityBlog} onClick={unmountAndClose}>
+                  Community Blog
                 </MobileNavLink>
                 <MobileNavLink variant="h4" nested external href={navLinks.whitepaper} onClick={unmountAndClose}>
                   Whitepaper


### PR DESCRIPTION
## Summary
- Updates the blog navigation to include both official and community blog links
- Replaces the old blog URL with the new official blog URL
- Adds community blog as a separate navigation item

## Changes Made
- **Updated `navLinks` object in `Navbar.tsx`**: Changed blog URL to official blog and added communityBlog link
- **Updated desktop navigation**: Modified `LearnNavi` component to show both "Official Blog" and "Community Blog" 
- **Updated mobile navigation**: Added both blog links with proper external link attributes

## URLs
- **Official Blog**: https://mirror.xyz/0x8F02813a0AC20affC2C7568e0CB9a7cE5288Ab27
- **Community Blog**: https://mirror.xyz/0xe7731147bBe1BEBe5CF1Ab101C6EceD384dAbD07

## Testing
- ✅ Build passes without TypeScript errors
- ✅ Both blog links open in new tabs with proper security attributes
- ✅ Navigation works correctly on both desktop and mobile
- ✅ Links are properly positioned under the Learn section

## Technical Details
- Both blog links use `rel="noopener noreferrer"` and `target="_blank"` for security
- Mobile navigation uses `external` prop to ensure proper link handling
- Desktop navigation uses `NavigationMenuItem` components with proper link attributes
- No breaking changes to existing navigation structure

🤖 Generated with [Claude Code](https://claude.ai/code)