### PR TITLE
Fix ComboInputField empty value and placeholder behavior

### DIFF
--- a/src/components/ComboInputField.tsx
+++ b/src/components/ComboInputField.tsx
@@ -65,6 +65,9 @@ export interface ComboInputProps extends InputHTMLAttributes<HTMLInputElement> {
 
   // Token select props
   transformTokenLabels?: TransformTokenLabelsFunction;
+  
+  // Input placeholder
+  placeholder?: string;
 }
 
 function ComboInputField({
@@ -101,6 +104,7 @@ function ComboInputField({
   filterTokens,
   selectKey,
   transformTokenLabels,
+  placeholder,
 }: ComboInputProps) {
   const tokenData = useTokenData();
   const { balances } = useFarmerBalances();
@@ -322,6 +326,7 @@ function ComboInputField({
                 min={0}
                 type="number"
                 disabled={disableInput}
+                placeholder={placeholder || "0"}
                 className={
                   "flex w-full pr-1 text-[2rem] h-[2.2rem] leading-[2.2rem] text-black font-[400] align-middle focus-visible:outline-none placeholder:text-muted-foreground disabled:cursor-not-allowed [appearance:textfield] [&::-webkit-outer-spin-button]:appearance-none [&::-webkit-inner-spin-button]:appearance-none disabled:opacity-50 disabled:bg-transparent"
                 }

--- a/src/utils/string.ts
+++ b/src/utils/string.ts
@@ -27,7 +27,7 @@ export const stringEq = (a: Stringable, b: Stringable) => {
 const invalidNumInputs = new Set([".", "e", "nan", "-", "+"]);
 
 export const toValidStringNumInput = (val: string): string => {
-  if (!val) return "0";
+  if (!val) return "";
   const valid = val.replace(/[e\-\+]/g, "");
   return valid;
 };


### PR DESCRIPTION
## Summary
Fixes the ComboInputField component to properly handle empty values and show placeholder text instead of defaulting to "0".

## Problem
- Input field defaulted to showing "0" instead of being empty with placeholder
- Users couldn't have truly empty input fields
- When typing in a field showing "0", it would concatenate as "0{number}" instead of replacing with "{number}"

## Solution
- **Fixed `toValidStringNumInput` function** in `src/utils/string.ts` to return empty string instead of "0" for empty input
- **Added placeholder prop support** to ComboInputField component
- **Updated input element** to show placeholder "0" when empty instead of actual value "0"

## Changes Made
1. **`src/utils/string.ts`**: Changed `toValidStringNumInput` to return `""` instead of `"0"` for empty input
2. **`src/components/ComboInputField.tsx`**: 
   - Added `placeholder?` prop to `ComboInputProps` interface
   - Added placeholder parameter to component function
   - Updated input element to use placeholder prop (defaults to "0")

## Testing
- Verified input shows placeholder "0" when empty
- Confirmed typing works correctly without "0" prefix
- Tested on Swap page and other token input fields
- Ensured existing functionality (max button, validation) still works

## Expected Behavior After Fix
- ✅ Input shows placeholder when empty (no "0" value)
- ✅ User can type numbers naturally without "0" prefix
- ✅ Empty values are properly handled
- ✅ Typing "5" results in "5", not "05"
- ✅ Input field can be cleared to empty state

🤖 Generated with [Claude Code](https://claude.ai/code)