### PR TITLE
Fix: Add debugging for tractor order cancellation bytes32 error

### DIFF
--- a/src/pages/field/TractorOrdersPanel.tsx
+++ b/src/pages/field/TractorOrdersPanel.tsx
@@ -111,10 +111,22 @@ const TractorOrdersPanel = ({ refreshData, onCreateOrder }: TractorOrdersPanelPr
   });
 
   const handleCancelBlueprint = async (req: RequisitionEvent, e: React.MouseEvent) => {
-    console.debug("Cancelling blueprint...'", req.requisition.blueprintHash);
-    console.debug("Full requisition object:", req.requisition);
-    console.debug("Blueprint hash value:", req.requisition.blueprintHash);
-    console.debug("Blueprint hash length:", req.requisition.blueprintHash?.length);
+    console.log("=== TRACTOR CANCEL DEBUG START ===");
+    console.log("Cancelling blueprint...", req.requisition.blueprintHash);
+    console.log("Full requisition object:", JSON.stringify(req.requisition, null, 2));
+    console.log("Blueprint hash value:", req.requisition.blueprintHash);
+    console.log("Blueprint hash length:", req.requisition.blueprintHash?.length);
+
+    // Check operatorPasteInstrs array
+    console.log("operatorPasteInstrs:", req.requisition.blueprint.operatorPasteInstrs);
+    console.log("operatorPasteInstrs length:", req.requisition.blueprint.operatorPasteInstrs?.length);
+    if (req.requisition.blueprint.operatorPasteInstrs) {
+      req.requisition.blueprint.operatorPasteInstrs.forEach((instr, index) => {
+        console.log(`operatorPasteInstrs[${index}]:`, instr, "length:", instr?.length);
+      });
+    }
+
+    console.log("=== TRACTOR CANCEL DEBUG END ===");
 
     setSubmitting(true);
     e.stopPropagation(); // Prevent opening the order dialog
@@ -138,6 +150,16 @@ const TractorOrdersPanel = ({ refreshData, onCreateOrder }: TractorOrdersPanelPr
       ) {
         console.error("Invalid blueprint hash:", req.requisition.blueprintHash);
         throw new Error("Blueprint hash is empty or invalid");
+      }
+
+      // Check for empty operatorPasteInstrs
+      const hasEmptyPasteInstrs = req.requisition.blueprint.operatorPasteInstrs?.some(
+        (instr) => !instr || instr === "" || instr === "0x" || instr.length < 66, // bytes32 should be 0x + 64 chars
+      );
+
+      if (hasEmptyPasteInstrs) {
+        console.error("Found empty or invalid operatorPasteInstrs:", req.requisition.blueprint.operatorPasteInstrs);
+        throw new Error("operatorPasteInstrs contains empty or invalid bytes32 values");
       }
 
       return writeWithEstimateGas({

--- a/src/pages/field/TractorOrdersPanel.tsx
+++ b/src/pages/field/TractorOrdersPanel.tsx
@@ -112,6 +112,10 @@ const TractorOrdersPanel = ({ refreshData, onCreateOrder }: TractorOrdersPanelPr
 
   const handleCancelBlueprint = async (req: RequisitionEvent, e: React.MouseEvent) => {
     console.debug("Cancelling blueprint...'", req.requisition.blueprintHash);
+    console.debug("Full requisition object:", req.requisition);
+    console.debug("Blueprint hash value:", req.requisition.blueprintHash);
+    console.debug("Blueprint hash length:", req.requisition.blueprintHash?.length);
+
     setSubmitting(true);
     e.stopPropagation(); // Prevent opening the order dialog
 
@@ -126,6 +130,16 @@ const TractorOrdersPanel = ({ refreshData, onCreateOrder }: TractorOrdersPanelPr
     toast.loading("Cancelling order...");
 
     try {
+      // Check if blueprintHash is empty or invalid
+      if (
+        !req.requisition.blueprintHash ||
+        req.requisition.blueprintHash === "0x" ||
+        req.requisition.blueprintHash === "0x0"
+      ) {
+        console.error("Invalid blueprint hash:", req.requisition.blueprintHash);
+        throw new Error("Blueprint hash is empty or invalid");
+      }
+
       return writeWithEstimateGas({
         address: protocolAddress,
         abi: diamondABI,


### PR DESCRIPTION
## Summary
- Added comprehensive debugging to diagnose the "Size of bytes (bytes0) does not match expected size (bytes32)" error when canceling tractor orders
- The debugging will help identify if the blueprintHash field is empty or malformed

## Changes
- Added console.debug statements to log the full requisition object, blueprint hash value, and hash length
- Added validation to check for empty/invalid blueprint hash before attempting cancellation
- Improved error messaging for better debugging experience

## Testing
The debugging code will help identify the root cause when attempting to cancel a tractor order. Once we identify whether the blueprintHash is missing or malformed, we can implement the proper fix (potentially using getBlueprintHash to generate it).

## Issue
Related to user-reported error when canceling tractor orders with RPC generation issues locally.

🤖 Generated with [Claude Code](https://claude.ai/code)