### PR TITLE
feat: combine Order Modifications and Constants into single New Order table

### DIFF
--- a/src/components/Tractor/ModifySowOrderDialog.tsx
+++ b/src/components/Tractor/ModifySowOrderDialog.tsx
@@ -383,33 +383,21 @@ function ModifyTractorOrderReviewDialog({
               {/* Show a comparison of old vs new */}
               <div className="bg-gray-50 p-4 rounded-lg mb-4">
                 <div className="space-y-4 text-sm">
-                  {/* Show differences between old and new order */}
+                  {/* Show all order parameters in single New Order table */}
                   {valueDiffs.modifications.length || valueDiffs.constants.length ? (
-                    <Col className="gap-4">
-                      {/* Order Modifications Section */}
-                      {valueDiffs.modifications.length > 0 && (
-                        <div>
-                          <h4 className="pinto-body font-medium text-pinto-secondary mb-2">Order Modifications</h4>
-                          <Col className="gap-2 pinto-sm-light">
-                            {valueDiffs.modifications.map(([key, value]) => {
-                              return <RenderValueDiff key={`sow-v0-diff-${key}`} {...value} />;
-                            })}
-                          </Col>
-                        </div>
-                      )}
-
-                      {/* Order Constants Section */}
-                      {valueDiffs.constants.length > 0 && (
-                        <div>
-                          <h4 className="pinto-body font-medium text-pinto-secondary mb-2">Order Constants</h4>
-                          <Col className="gap-2 pinto-sm-light">
-                            {valueDiffs.constants.map(([key, value]) => {
-                              return <RenderConstantParam key={`sow-v0-constant-${key}`} {...value} />;
-                            })}
-                          </Col>
-                        </div>
-                      )}
-                    </Col>
+                    <div>
+                      <h4 className="pinto-body font-medium text-pinto-secondary mb-2">New Order</h4>
+                      <Col className="gap-2 pinto-sm-light">
+                        {/* Show modifications first */}
+                        {valueDiffs.modifications.map(([key, value]) => {
+                          return <RenderValueDiff key={`sow-v0-diff-${key}`} {...value} />;
+                        })}
+                        {/* Show constants after modifications */}
+                        {valueDiffs.constants.map(([key, value]) => {
+                          return <RenderConstantParam key={`sow-v0-constant-${key}`} {...value} />;
+                        })}
+                      </Col>
+                    </div>
                   ) : (
                     <div className="pinto-body text-pinto-light text-center h-[2rem] flex items-center justify-center">
                       No changes


### PR DESCRIPTION
## Summary
- Combined separate "Order Modifications" and "Order Constants" sections into a unified "New Order" table in the Review Order Modification dialog
- Improves UX by reducing visual complexity while maintaining all functionality

## Changes
- Merged the two sections under a single "New Order" heading
- Modifications are displayed first with before/after comparison arrows
- Constants are shown after with their current values
- Maintained all existing styling and functionality

## Test plan
- [x] Build passes successfully
- [x] Code formatting and linting applied
- [x] All existing functionality preserved
- [ ] Manual testing of the order modification flow

🤖 Generated with [Claude Code](https://claude.ai/code)