### PR TITLE
Fix UI copy grammar and capitalization issues

### DIFF
--- a/src/pages/Collection.tsx
+++ b/src/pages/Collection.tsx
@@ -129,7 +129,7 @@ function EmptyState() {
     <div className="flex flex-col items-center justify-center py-16 px-4">
       <div className="text-center max-w-md">
         <div className="pinto-h3 mb-4 text-pinto-dark">No NFT Found</div>
-        <div className="pinto-body text-pinto-light mb-6">You can purchase one from a NFT marketplace.</div>
+        <div className="pinto-body text-pinto-light mb-6">You can purchase one from an NFT marketplace.</div>
         <Button
           asChild
           variant="outline"

--- a/src/pages/overview/NewUserView.tsx
+++ b/src/pages/overview/NewUserView.tsx
@@ -175,7 +175,7 @@ const flowCards: {
         <InlineFlex>
           <PintoIcon /> Depositors
         </InlineFlex>{" "}
-        <span>can</span> <span>convert</span> <span>LP</span> <span>into</span> <span>Pinto</span> <span>to</span>{" "}
+        <span>can</span> <span>Convert</span> <span>LP</span> <span>into</span> <span>Pinto</span> <span>to</span>{" "}
         <span>buy</span> <span>at</span> <span>a</span> <span>lower</span> <span>price</span>
       </FlowCard>
     ),


### PR DESCRIPTION
## Summary
- Fixed grammatical error: "a NFT marketplace" → "an NFT marketplace" in Collection page
- Fixed capitalization: "convert" → "Convert" in Overview page for consistency with other UI elements

## Changes Made
- **Collection.tsx**: Updated empty state message grammar
- **NewUserView.tsx**: Capitalized "Convert" in depositor flow card text

## Test plan
- [x] Verify Collection page displays correct grammar when wallet has no NFTs
- [x] Verify Overview page shows capitalized "Convert" for wallets with no deposits
- [x] Check that no other functionality is affected

🤖 Generated with [Claude Code](https://claude.ai/code)