### PR TITLE
fix: reorder workflow steps to fix 'Head sha can't be blank' error

### DIFF
--- a/.github/workflows/ai-implement.yml
+++ b/.github/workflows/ai-implement.yml
@@ -164,6 +164,26 @@ jobs:
             - Prefer existing patterns and conventions in this repository (as documented in `CLAUDE.md`
               and in the existing code).
 
+      - name: Ensure feature branch exists
+        if: success()
+        run: |
+          BRANCH_NAME=$(git branch --show-current)
+          ISSUE_NUMBER="${{ github.event.issue.number }}"
+
+          echo "Current branch after Claude action: $BRANCH_NAME"
+
+          # Check if we're on a feature branch, create one if not
+          if [[ "$BRANCH_NAME" == "main" ]]; then
+            echo "⚠️ Still on main branch - creating feature branch for issue #$ISSUE_NUMBER"
+            TIMESTAMP=$(date +%Y%m%d-%H%M)
+            NEW_BRANCH="claude/issue-$ISSUE_NUMBER-$TIMESTAMP"
+            git checkout -b "$NEW_BRANCH"
+            BRANCH_NAME="$NEW_BRANCH"
+            echo "✅ Created and switched to branch: $BRANCH_NAME"
+          fi
+
+          echo "Working on branch: $BRANCH_NAME"
+
       - name: Format and lint code
         if: success()
         run: |
@@ -180,33 +200,49 @@ jobs:
           🤖 Generated with [Claude Code](https://claude.com/claude-code)
 
           Co-Authored-By: Claude <noreply@anthropic.com>"
-            git push -u origin HEAD
+            echo "✅ Committed formatting changes"
           else
             echo "No formatting changes needed"
           fi
 
-      - name: Ensure branch is pushed
+      - name: Push all commits to remote
         if: success()
         run: |
           BRANCH_NAME=$(git branch --show-current)
-          ISSUE_NUMBER="${{ github.event.issue.number }}"
 
-          # Check if we're on a feature branch, create one if not
-          if [[ "$BRANCH_NAME" == "main" ]]; then
-            echo "⚠️ Still on main branch - creating feature branch for issue #$ISSUE_NUMBER"
-            TIMESTAMP=$(date +%Y%m%d-%H%M)
-            NEW_BRANCH="claude/issue-$ISSUE_NUMBER-$TIMESTAMP"
-            git checkout -b "$NEW_BRANCH"
-            BRANCH_NAME="$NEW_BRANCH"
-            echo "✅ Created and switched to branch: $BRANCH_NAME"
+          # Check if there are any commits on this branch that aren't on main
+          COMMIT_COUNT=$(git rev-list --count main..HEAD)
+
+          if [[ "$COMMIT_COUNT" -eq 0 ]]; then
+            echo "❌ No commits found on branch $BRANCH_NAME"
+            echo "This indicates Claude action did not make any changes and formatting also made no changes."
+            echo "This is unexpected - the workflow should not reach this point without changes."
+            exit 1
           fi
 
-          echo "Current branch: $BRANCH_NAME"
+          echo "✅ Found $COMMIT_COUNT commit(s) to push"
 
-          # Ensure the branch exists on remote and is up to date
+          # Push all commits to remote
           git push -u origin HEAD --force-with-lease
 
-          echo "✅ Branch pushed to remote"
+          echo "✅ Pushed $COMMIT_COUNT commit(s) to remote"
+
+          # Give GitHub API more time to replicate refs across zones
+          echo "Waiting for GitHub API to replicate..."
+          sleep 5
+
+          # Verify remote has the commits
+          git fetch origin "$BRANCH_NAME" 2>/dev/null || true
+          REMOTE_COMMITS=$(git rev-list --count main..origin/"$BRANCH_NAME" 2>/dev/null || echo "0")
+
+          if [[ "$REMOTE_COMMITS" -eq 0 ]]; then
+            echo "⚠️ Remote branch not showing commits yet, waiting additional time..."
+            sleep 3
+            git fetch origin "$BRANCH_NAME"
+            REMOTE_COMMITS=$(git rev-list --count main..origin/"$BRANCH_NAME" 2>/dev/null || echo "0")
+          fi
+
+          echo "✅ Remote branch has $REMOTE_COMMITS commit(s)"
 
       - name: Create or update PR
         if: success()
@@ -215,36 +251,9 @@ jobs:
           BRANCH_NAME=$(git branch --show-current)
           ISSUE_NUMBER="${{ github.event.issue.number }}"
 
-          # Check if there are any commits on this branch that aren't on main
+          # Verify we have commits (should always be true at this point)
           COMMIT_COUNT=$(git rev-list --count main..HEAD)
-          if [[ "$COMMIT_COUNT" -eq 0 ]]; then
-            echo "⚠️ No commits found on branch $BRANCH_NAME"
-            echo "Creating a placeholder commit to track this issue attempt..."
-
-            # Create a placeholder file to have something to commit
-            mkdir -p .github/claude-attempts
-            echo "Issue #$ISSUE_NUMBER - $(date -u +"%Y-%m-%d %H:%M:%S UTC")" > .github/claude-attempts/issue-$ISSUE_NUMBER.txt
-            echo "Claude attempted to implement this issue but made no code changes." >> .github/claude-attempts/issue-$ISSUE_NUMBER.txt
-            echo "This may indicate the issue needs clarification or was already resolved." >> .github/claude-attempts/issue-$ISSUE_NUMBER.txt
-
-            git add .github/claude-attempts/issue-$ISSUE_NUMBER.txt
-            git commit -m "chore: track Claude attempt for issue #$ISSUE_NUMBER
-
-No code changes were made by Claude. This commit tracks the attempt.
-
-🤖 Generated with [Claude Code](https://claude.com/claude-code)
-
-Co-Authored-By: Claude Sonnet 4.5 <noreply@anthropic.com>"
-            git push -u origin HEAD
-
-            COMMIT_COUNT=1
-            echo "✅ Created tracking commit"
-          fi
-
-          echo "✅ Found $COMMIT_COUNT commit(s) on branch $BRANCH_NAME"
-
-          # Give GitHub a moment to process the push
-          sleep 2
+          echo "✅ Creating PR with $COMMIT_COUNT commit(s) on branch $BRANCH_NAME"
 
           # Check if PR already exists for this branch
           EXISTING_PR=$(gh pr list --head "$BRANCH_NAME" --json number --jq '.[0].number' 2>/dev/null || true)


### PR DESCRIPTION
## Problem

The AI-implement workflow was failing with:
```
GraphQL: Head sha can't be blank, Base sha can't be blank, 
No commits between main and branch
```

## Root Cause Analysis

The workflow had a **critical sequencing issue** where formatting/linting ran on the wrong branch:

### The Broken Flow:
1. ✅ Claude Code action creates commits on feature branch
2. ❌ Action returns control while still on `main` branch
3. ❌ Format/lint steps run on `main` (wrong branch!)
4. ❌ Commit formatting pushes to `main` (wrong!)
5. ⚠️ "Ensure branch is pushed" detects we're still on main
6. ⚠️ Creates NEW empty feature branch
7. ❌ PR creation fails: GitHub can't find commits between branches

### Why GitHub API Returned "Head sha can't be blank":
- The feature branch was created AFTER commits were made
- Branch had no unique commits relative to main initially
- The placeholder commit logic tried to fix this but timing was wrong
- 2-second wait was insufficient for GitHub's API replication
- GitHub couldn't find refs for the newly created branch

## Solution

**Reordered workflow steps** to establish correct branch context early:

### New Step Order:
1. **Run Claude Issue Implement** (lines 80-166)
2. **Ensure feature branch exists** (lines 167-185) - **MOVED BEFORE formatting**
   - Detects if still on main
   - Creates feature branch if needed
   - Switches to feature branch BEFORE any modifications
3. **Format and lint code** (lines 187-191) - now runs on correct branch
4. **Commit formatting changes** (lines 193-206) - commits but doesn't push
5. **Push all commits to remote** (lines 208-245) - **NEW consolidated step**
   - Pushes both Claude's commits + formatting together atomically
   - Increased wait time: 2s → 5s for GitHub API replication
   - Added verification that remote has commits
   - Extra 3s wait + retry if remote not synced
   - Fail-fast if no commits (indicates workflow error)
6. **Create or update PR** (lines 247-310) - **simplified**
   - Removed placeholder commit logic (no longer needed)
   - Should always have commits at this point
   - Cleaner error handling

## Key Improvements

### 1. Branch Context Established Early
- Feature branch created/verified immediately after Claude action
- All subsequent steps run on correct branch
- No more commits accidentally going to main

### 2. Atomic Push of All Commits
- Both Claude's changes and formatting pushed together
- No intermediate pushes that could cause timing issues
- Single point of synchronization

### 3. Extended GitHub API Wait Time
- Increased from 2s to 5s base wait
- Added verification that remote has commits
- Extra 3s retry if remote not ready
- Accounts for GitHub's distributed API replication time

### 4. Better Error Handling
- Fail-fast if no commits exist (indicates workflow bug)
- Remote commit verification before PR creation
- Clear error messages at each validation point

### 5. Cleaner Code
- Removed placeholder commit workaround
- More predictable execution flow
- Each step has single responsibility

## Testing Recommendations

After merge, test with:
1. ✅ Issue that requires code changes
2. ✅ Issue that requires only formatting
3. ✅ Issue where Claude makes no changes (should fail gracefully)
4. ✅ Verify all commits appear in final PR

## Related Issues

This supersedes and closes PR #345 which attempted to fix similar issues but didn't address the root cause.

🤖 Generated with [Claude Code](https://claude.com/claude-code)