### PR TITLE
chore: switch Claude workflows to OAuth token

### DIFF
--- a/.github/workflows/ai-implement.yml
+++ b/.github/workflows/ai-implement.yml
@@ -81,7 +81,7 @@ jobs:
         id: claude
         uses: anthropics/claude-code-action@v1.0.29
         with:
-          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           github_token: ${{ secrets.GITHUB_TOKEN }}
           timeout_minutes: 25
           max_turns: 10

--- a/.github/workflows/claude-pr-review-fix.yml
+++ b/.github/workflows/claude-pr-review-fix.yml
@@ -129,7 +129,7 @@ jobs:
       - name: Run Claude PR Review & Fix
         uses: anthropics/claude-code-action@v1.0.29
         with:
-          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           github_token: ${{ secrets.GITHUB_TOKEN }}
           timeout_minutes: "25"
           initial_prompt: |


### PR DESCRIPTION
## Summary
- Switch from `ANTHROPIC_API_KEY` to `CLAUDE_CODE_OAUTH_TOKEN` in both Claude workflow files
- This uses Claude subscription billing instead of API credits

## Changes
- `ai-implement.yml` - updated auth parameter
- `claude-pr-review-fix.yml` - updated auth parameter

**Note:** This replaces PR #385 which added duplicate/conflicting workflows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)