### PR TITLE
fix: update ComboInputField to support balances from custom maps

### DIFF
--- a/src/components/ComboInputField.tsx
+++ b/src/components/ComboInputField.tsx
@@ -247,10 +247,9 @@ function ComboInputField({
     if (mode === "plots" && selectedPlots) {
       return selectedPlots.reduce((total, plot) => total.add(plot.pods), TokenValue.ZERO);
     }
-    if (mode === "balance") {
-      if (tokenAndBalanceMap && selectedToken) {
-        return tokenAndBalanceMap.get(selectedToken) ?? TokenValue.ZERO;
-      }
+    // If tokenAndBalanceMap is provided and selectedToken exists, use it (for deposits mode or custom balance maps)
+    if (tokenAndBalanceMap && selectedToken) {
+      return tokenAndBalanceMap.get(selectedToken) ?? TokenValue.ZERO;
     }
     // Always use farmerTokenBalance for display, not maxAmount (which may be limited by customMaxAmount)
     return getFarmerBalanceByMode(farmerTokenBalance, balanceFrom);

--- a/src/pages/field/actions/Sow.tsx
+++ b/src/pages/field/actions/Sow.tsx
@@ -478,6 +478,7 @@ function Sow({ isMorning, onShowOrder }: SowProps) {
           transformTokenLabels={fromSilo ? transformTokenLabels : undefined}
           tokenAndBalanceMap={fromSilo ? depositedByWhitelistedToken : undefined}
           balanceFrom={fromSilo ? undefined : balanceFrom}
+          mode={fromSilo ? "deposits" : undefined}
           disableButton={isConfirming}
           connectedAccount={!!account.address}
           altText={balanceExceedsSoil ? "Usable balance:" : undefined}


### PR DESCRIPTION
Update the balance retrieval logic to prioritize provided token maps and specify the deposits mode within the Sow action component.